### PR TITLE
fix: uses .fifo for fifo queue suffix

### DIFF
--- a/base/SQS.ts
+++ b/base/SQS.ts
@@ -3,9 +3,12 @@ import { Construct } from 'constructs';
 
 export class SqsQueue extends aws_SqsQueue {
     constructor(scope: Construct, id: string, config: SqsQueueConfig) {
-        const checkedConfig = { ...config };
-        checkedConfig.name = `${config?.name}-sqs`;
-
+        const { name, fifoQueue } = config;
+        const checkedConfig = {
+            ...config,
+            name: `${name}${fifoQueue ? '.fifo' : '-sqs'}`,
+        };
+        
         super(scope, `asm/${id}`, checkedConfig);
     }
 };


### PR DESCRIPTION
The FIFO queue name must end with `.fifo`. Currently, it incorrectly ends with `-sqs`, which causes deployment to fail.
This PR ensures the queue name uses the correct suffix (`.fifo` for FIFO queues, `-sqs` for standard queues).